### PR TITLE
Minor fixes for private hosting

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -35,7 +35,8 @@ else
     REVIEW_CONTENT="Oops :fearful: ${DRONE_REPO_LINK}/commit/${DRONE_COMMIT_SHA} CI test failed :exclamation: \n\n@${DRONE_COMMIT_AUTHOR} please take a look at CI build ${DRONE_BUILD_LINK} for details :memo: !\n Most of the error will have corresponding explanation, so that you will know what's wrong and then try to fix it!\n If you cannot understand the error message and need help, feel free to ask  our maintainers :relaxed: "
 fi
 
-API_URL="https://api.github.com/repos/${DRONE_REPO}/pulls/${DRONE_PULL_REQUEST}/reviews"
+GITHUB_API_HOST=${GITHUB_API_HOST:-https://api.github.com}
+API_URL="${GITHUB_API_HOST}/repos/${DRONE_REPO}/pulls/${DRONE_PULL_REQUEST}/reviews"
 REVIEW="{ \"body\": \"${REVIEW_CONTENT}\", \"event\": \"${REVIEW_EVENT}\"}"
 
 curl --silent -H "Accept: application/vnd.github.black-cat-preview+json" -H "Authorization: token ${GITHUB_TOKEN}" -d "${REVIEW}" "${API_URL}" > /dev/null

--- a/main.sh
+++ b/main.sh
@@ -13,7 +13,7 @@ if [ "${CI}" != "drone" ] && [ "${DRONE}" != "true" ]; then
     err "Not a Drone CI environment"
 fi
 
-if ! echo "${DRONE_REPO_LINK}" | grep -q 'github.com'; then
+if ! echo "${DRONE_REPO_LINK}" | grep -q 'github'; then
     err "Repository is not on GitHub"
 fi
 


### PR DESCRIPTION
* Unhardcode the API_HOST to allow private instances
  * It maintains the current behaviour just adds the possibility to set an environment variable called GITHUB_API_HOST to use a different host

* Relax the requirement on the domain
  * It still checking it has github on the domain. It allows private instances like we have in cisco for example.

If you decide to accept it, please do a new docker image with these changes. I would like to keep using your docker image instead of having a copy in our side.
